### PR TITLE
Add Riftbound card image fetching support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Lore-Book/
 │   │   ├── features.py        # get_extractor("keras"|"tflite"), extract_features(+_batch), heatmap
 │   │   ├── card_database.py   # Feature cache build/load, set_database_path
 │   │   ├── card_names.py      # Optional card-name lookup (card_names_<Game>.json)
-│   │   ├── image_fetcher.py   # download_new_images — card art from LorcanaJSON
+│   │   ├── image_fetcher.py   # download_new_images — card art from LorcanaJSON / Riot API (Riftcodex fallback)
 │   │   └── csv_manager.py     # CSV read/write, update_cardlist(_batch), split_filename
 │   ├── hardware/          # Hardware abstraction (no Qt; mocks run on any desktop)
 │   │   ├── camera.py          # open_capture, CameraSource, OpenCVCameraSource, MockCameraSource
@@ -80,7 +80,7 @@ Lore-Book/
 | `lorebook/core/game_types.py` | `GameType` enum, `get_game_type()`, `game_type_from_name()`, `csv_for_game()`, constants |
 | `lorebook/core/image_utils.py` | `ensure_valid_image`, `foil_score`, `is_probably_foil`, `focus_rect`/`crop_to_card` (shared GUI/sorter card crop), `MotionGate` (auto-scan) |
 | `lorebook/core/card_names.py` | `name_for()` — optional display names from `card_names_<Game>.json` (see `scripts/fetch_card_names.py`) |
-| `lorebook/core/image_fetcher.py` | `download_new_images()` — fetch missing card art from LorcanaJSON into `Card_Images/<Game>/` (auto-run by the GUI's Rebuild Database; CLI: `scripts/fetch_card_images.py`) |
+| `lorebook/core/image_fetcher.py` | `download_new_images()` — fetch missing card art into `Card_Images/<Game>/` (Lorcana: LorcanaJSON; Riftbound: Riot content API when `RIOT_API_KEY` is set, else Riftcodex). Auto-run by the GUI's Rebuild Database; CLI: `scripts/fetch_card_images.py` |
 | `lorebook/core/matching.py` | `_l2_normalize`, `_cosine_score`, `find_best_matches`, `MatchIndex` (vectorized) |
 | `lorebook/core/features.py` | `get_extractor(backend)` (keras/tflite), `extract_features`, `visualize_activation_overlay` |
 | `lorebook/core/card_database.py` | `databasePath` global, `set_database_path`, `load_cache`, `build_feature_database` |
@@ -214,7 +214,7 @@ Examples: `001-042.webp`, `ONG-23c-alt.jpg`
 - **Tune foil detection** — adjust `foil_score()` weights or threshold in `is_probably_foil()` (`lorebook/core/image_utils.py`).
 - **Change match threshold** — core default is `0.70` in `find_best_matches()` / `MatchIndex.find()` (`lorebook/core/matching.py`); the GUI ships a stricter `0.90` default, exposed in Settings as confidence %. See `docs/MATCHING.md` for how the whole pipeline fits together.
 - **Show card names** — run `python scripts/fetch_card_names.py --game <Game>` once; the GUI/sorter pick up `card_names_<Game>.json` automatically (display-only, never written to the CSV).
-- **Get a new set's images** — the GUI's Rebuild Database button auto-downloads missing Lorcana card art from LorcanaJSON before rebuilding (offline → warning logged, build continues). CLI: `python scripts/fetch_card_images.py --game Lorcana [--set <N>] [--dry-run]`. Only Lorcana has a registered fetcher (`GAMES` in `lorebook/core/image_fetcher.py`); other games are skipped silently.
+- **Get a new set's images** — the GUI's Rebuild Database button auto-downloads missing card art before rebuilding (offline → warning logged, build continues). Lorcana pulls from LorcanaJSON; Riftbound uses the official Riot content API when the `RIOT_API_KEY` env var is set and falls back to the open Riftcodex API otherwise. CLI: `python scripts/fetch_card_images.py --game <Game> [--set <N>] [--dry-run]`. Registered fetchers live in `GAMES` (`lorebook/core/image_fetcher.py`); unregistered games are skipped silently.
 - **Change sort routing** — edit the rules JSON (see `configs/sort_rules.example.json`); the engine is `decide_bin()` in `lorebook/sorter/rules.py`. Unmatched cards always go to `reject_bin`.
 - **Implement the real transport** — subclass `Transport` (`lorebook/hardware/transport.py`); the pipeline needs `route_to_bin`, `advance`, `home`.
 - **Cache issues** — delete `DBCardCache_<game>.db` and rebuild with `--build` flag.
@@ -229,4 +229,5 @@ Examples: `001-042.webp`, `ONG-23c-alt.jpg`
 - Camera index `0` may not be correct on machines with multiple cameras — adjust in Settings.
 - `foil_score` threshold (default `0.08`) was tuned empirically; may need adjustment per lighting setup.
 - `riot.txt` at the repo root is a Riot Games API domain-verification token — don't delete it.
+- Riftbound image fetching prefers the official Riot API (`RIOT_API_KEY` env var; dev keys from developer.riotgames.com expire every 24 h) and silently falls back to Riftcodex without one, so keyless runs still work. The two sources' JSON shapes are both handled by `riftbound_targets()`.
 - `PySide6` is pinned to the 6.8 LTS line for NumPy 2 compatibility (6.6's shiboken predates NumPy 2; 6.11.1 fails to bootstrap on Windows/Py3.12) — see the comment in `requirements.txt` before bumping.

--- a/lorebook/core/image_fetcher.py
+++ b/lorebook/core/image_fetcher.py
@@ -160,9 +160,11 @@ def _fetch_riftbound(url: str):
 
 
 def _first_field(card: dict, *names):
+    """First non-empty scalar among the named fields (nested objects don't
+    stringify into usable codes/URLs, so they count as missing)."""
     for name in names:
         value = card.get(name)
-        if value not in (None, ""):
+        if isinstance(value, (str, int)) and str(value).strip():
             return value
     return None
 

--- a/lorebook/core/image_fetcher.py
+++ b/lorebook/core/image_fetcher.py
@@ -8,8 +8,11 @@
 # card_names lookups line up. Existing files are skipped, so re-running only
 # downloads what's new.
 #
-# Source (community-maintained; pass url= if the format changes):
-#   Lorcana — LorcanaJSON bulk data   https://lorcanajson.org
+# Sources (pass url= if a format changes):
+#   Lorcana   — LorcanaJSON bulk data (community)   https://lorcanajson.org
+#   Riftbound — Riot content API (official, needs RIOT_API_KEY env var)
+#               https://developer.riotgames.com/docs/riftbound
+#               falls back to the open Riftcodex API   https://riftcodex.com
 #
 # Note: card art is copyrighted by Ravensburger/Riot. Downloads are local, for
 # personal-collection use only (Card_Images/ is gitignored); nothing is
@@ -23,8 +26,11 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from typing import Callable, Iterable, Iterator, Optional, Tuple
+from urllib.parse import urlsplit
 
 LORCANA_URL = "https://lorcanajson.org/files/current/en/allCards.json"
+RIFTBOUND_RIOT_URL = "https://americas.api.riotgames.com/riftbound/content/v1/contents?locale=en"
+RIFTBOUND_FALLBACK_URL = "https://riftcodex.com/api/cards"
 
 # A UA header — the Ravensburger image CDN can 403 an empty urllib agent.
 _UA = "Lore-Book-image-fetcher/1.0 (+https://github.com/; personal collection tool)"
@@ -38,8 +44,8 @@ class FetchStats:
     failed: int = 0
 
 
-def _fetch_json(url: str):
-    req = urllib.request.Request(url, headers={"User-Agent": _UA})
+def _fetch_json(url: str, headers: Optional[dict] = None):
+    req = urllib.request.Request(url, headers={"User-Agent": _UA, **(headers or {})})
     with urllib.request.urlopen(req, timeout=120) as resp:
         return json.load(resp)
 
@@ -96,9 +102,118 @@ def lorcana_targets(data) -> Iterator[Tuple[str, str, str]]:
         yield set_code, number, best[(set_code, number)][1]
 
 
+def _riot_api_key() -> str:
+    return os.environ.get("RIOT_API_KEY", "").strip()
+
+
+def _is_riot_host(url: str) -> bool:
+    host = urlsplit(url).hostname or ""
+    return host == "api.riotgames.com" or host.endswith(".api.riotgames.com")
+
+
+def _fetch_riftbound_pages(url: str) -> list:
+    """
+    Fetch all cards from an offset-paginated card list (Riftcodex-style,
+    48-card pages): keep requesting until a page comes back short or repeats.
+    """
+    cards, offset, last_first_id = [], 0, None
+    for _ in range(200):  # hard cap: never loop forever on a misbehaving API
+        sep = "&" if "?" in url else "?"
+        page = _fetch_json(f"{url}{sep}offset={offset}" if offset else url)
+        if isinstance(page, dict):
+            page = page.get("cards", [])
+        if not page:
+            break
+        first_id = page[0].get("id") if isinstance(page[0], dict) else None
+        if first_id is not None and first_id == last_first_id:
+            break  # API ignored the offset; stop rather than duplicate
+        last_first_id = first_id
+        cards.extend(page)
+        if len(page) < 48:
+            break
+        offset += len(page)
+    return cards
+
+
+def _fetch_riftbound(url: str):
+    """
+    Fetch the Riftbound card list. On the default URL, the official Riot
+    content endpoint is used when RIOT_API_KEY is set; without a key — or if
+    the Riot call fails — the open Riftcodex API is used instead. An explicit
+    url= override is fetched as-is (the key header is only ever attached to
+    *.api.riotgames.com hosts).
+    """
+    key = _riot_api_key()
+    if url == RIFTBOUND_RIOT_URL:
+        if not key:
+            logging.info(f"RIOT_API_KEY not set; using {RIFTBOUND_FALLBACK_URL}")
+            return _fetch_riftbound_pages(RIFTBOUND_FALLBACK_URL)
+        try:
+            return _fetch_json(url, headers={"X-Riot-Token": key})
+        except Exception as e:
+            logging.warning(f"Riot API fetch failed ({e}); "
+                            f"falling back to {RIFTBOUND_FALLBACK_URL}")
+            return _fetch_riftbound_pages(RIFTBOUND_FALLBACK_URL)
+    if _is_riot_host(url):
+        return _fetch_json(url, headers={"X-Riot-Token": key} if key else None)
+    return _fetch_riftbound_pages(url)
+
+
+def _first_field(card: dict, *names):
+    for name in names:
+        value = card.get(name)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _riftbound_cards(data) -> Iterator[dict]:
+    """Flatten either Riftbound payload shape into a stream of card dicts."""
+    if isinstance(data, dict):
+        if isinstance(data.get("sets"), list):  # Riot content: sets → cards
+            for s in data["sets"]:
+                if isinstance(s, dict):
+                    yield from (c for c in s.get("cards") or [] if isinstance(c, dict))
+            return
+        data = data.get("cards", [])
+    yield from (c for c in data or [] if isinstance(c, dict))
+
+
+def riftbound_targets(data) -> Iterator[Tuple[str, str, str]]:
+    """
+    Yield (set_code, number, image_url) for every Riftbound card with art.
+
+    Handles both source payload shapes — the Riot content endpoint (sets →
+    cards with art.fullUrl) and the Riftcodex card list (flat cards with
+    media.image_url) — tolerating camelCase/snake_case spellings. Duplicate
+    set/number keys keep the first occurrence (there is no promo-collision
+    rule like Lorcana's).
+    """
+    seen = set()
+    for card in _riftbound_cards(data):
+        set_code = str(_first_field(card, "set", "setCode", "set_code", "set_id") or "").strip()
+        number = str(_first_field(card, "collectorNumber", "collector_number", "number") or "").strip()
+        art = card.get("art")
+        media = card.get("media")
+        url = (
+            _first_field(art if isinstance(art, dict) else {},
+                         "fullUrl", "full_url", "thumbnailUrl", "thumbnail_url")
+            or _first_field(media if isinstance(media, dict) else {}, "image_url", "imageUrl")
+            or _first_field(card, "image_url", "imageUrl", "image")
+        )
+        if not (set_code and number and isinstance(url, str)):
+            continue
+        key = (set_code, number)
+        if key in seen:
+            continue
+        seen.add(key)
+        yield set_code, number, url
+
+
 # game key (lowercased folder name) → (bulk-data URL, fetcher, targets fn)
 GAMES = {
     "lorcana": (LORCANA_URL, _fetch_json, lorcana_targets),
+    "riftbound": (RIFTBOUND_RIOT_URL, _fetch_riftbound, riftbound_targets),
 }
 
 
@@ -149,7 +264,7 @@ def download_new_images(
     Download any missing card images for a game into out_dir.
 
     game: game folder name (e.g. "Lorcana"). Returns None when no fetcher is
-    registered for it (e.g. Riftbound) — callers should skip silently.
+    registered for it in GAMES — callers should skip silently.
     out_dir: defaults to Card_Images/<Game>.
     progress_callback: receives one-line status strings (per-image and summary).
     sets: restrict to these set codes ('9' and '009' both match); None = all.

--- a/tests/test_image_fetcher.py
+++ b/tests/test_image_fetcher.py
@@ -5,11 +5,15 @@ import pytest
 
 from lorebook.core import image_fetcher
 from lorebook.core.image_fetcher import (
+    RIFTBOUND_FALLBACK_URL,
+    RIFTBOUND_RIOT_URL,
     FetchStats,
+    _fetch_riftbound,
     _norm,
     _pad,
     download_new_images,
     lorcana_targets,
+    riftbound_targets,
 )
 
 
@@ -77,6 +81,136 @@ class TestLorcanaTargets:
             assert targets[("10", "99")] == "http://img/only.jpg"  # promo-only key kept
 
 
+class TestRiftboundTargets:
+    def test_parses_riot_content_shape(self):
+        data = {"sets": [{"id": "OGN", "cards": [
+            {"set": "OGN", "collectorNumber": 1,
+             "art": {"fullUrl": "http://img/full.jpg", "thumbnailUrl": "http://img/thumb.jpg"}},
+        ]}]}
+        assert list(riftbound_targets(data)) == [("OGN", "1", "http://img/full.jpg")]
+
+    def test_riot_thumbnail_used_only_without_full(self):
+        data = {"sets": [{"cards": [
+            {"set": "OGN", "collectorNumber": 2, "art": {"thumbnailUrl": "http://img/thumb.jpg"}},
+        ]}]}
+        assert list(riftbound_targets(data)) == [("OGN", "2", "http://img/thumb.jpg")]
+
+    def test_parses_riftcodex_shape(self):
+        cards = [
+            {"set_id": "OGN", "collector_number": "23c", "media": {"image_url": "http://img/23c.png"}},
+            {"set": "OGN", "number": 24, "image_url": "http://img/24.png"},
+        ]
+        for data in (cards, {"cards": cards}):  # bare list or wrapper
+            assert list(riftbound_targets(data)) == [
+                ("OGN", "23c", "http://img/23c.png"),
+                ("OGN", "24", "http://img/24.png"),
+            ]
+
+    def test_skips_incomplete_cards(self):
+        data = [
+            {"set": "OGN", "collectorNumber": 1},                        # no image
+            {"collectorNumber": 2, "image_url": "u"},                    # no set
+            {"set": "OGN", "image_url": "u"},                            # no number
+            {"set": "OGN", "collectorNumber": 3, "image": {"x": "y"}},   # non-string url
+            "not-a-dict",
+        ]
+        assert list(riftbound_targets(data)) == []
+
+    def test_tolerates_none_and_empty(self):
+        assert list(riftbound_targets(None)) == []
+        assert list(riftbound_targets({})) == []
+        assert list(riftbound_targets({"sets": []})) == []
+
+    def test_dedupes_on_first_occurrence(self):
+        data = [
+            {"set": "OGN", "number": 1, "image_url": "http://img/first.png"},
+            {"set": "OGN", "number": 1, "image_url": "http://img/second.png"},
+        ]
+        assert list(riftbound_targets(data)) == [("OGN", "1", "http://img/first.png")]
+
+
+class TestFetchRiftbound:
+    """Source selection and pagination, with _fetch_json stubbed (no network)."""
+
+    def _record(self, monkeypatch, responses):
+        """Stub _fetch_json: log (url, headers) calls, reply from `responses`
+        (a callable or a static value)."""
+        calls = []
+
+        def fake(url, headers=None):
+            calls.append((url, headers or {}))
+            return responses(url) if callable(responses) else responses
+
+        monkeypatch.setattr(image_fetcher, "_fetch_json", fake)
+        return calls
+
+    def test_key_set_uses_riot_endpoint_with_token(self, monkeypatch):
+        monkeypatch.setenv("RIOT_API_KEY", "RGAPI-test")
+        riot_data = {"sets": [{"cards": []}]}
+        calls = self._record(monkeypatch, riot_data)
+        assert _fetch_riftbound(RIFTBOUND_RIOT_URL) == riot_data
+        assert calls == [(RIFTBOUND_RIOT_URL, {"X-Riot-Token": "RGAPI-test"})]
+
+    def test_no_key_falls_back_to_riftcodex(self, monkeypatch):
+        monkeypatch.delenv("RIOT_API_KEY", raising=False)
+        cards = [{"id": 1}]
+        calls = self._record(monkeypatch, cards)
+        assert _fetch_riftbound(RIFTBOUND_RIOT_URL) == cards
+        assert calls == [(RIFTBOUND_FALLBACK_URL, {})]
+
+    def test_riot_failure_falls_back_to_riftcodex(self, monkeypatch):
+        monkeypatch.setenv("RIOT_API_KEY", "RGAPI-test")
+        cards = [{"id": 1}]
+
+        def responses(url):
+            if url.startswith(RIFTBOUND_FALLBACK_URL):
+                return cards
+            raise OSError("403 Forbidden")
+
+        calls = self._record(monkeypatch, responses)
+        assert _fetch_riftbound(RIFTBOUND_RIOT_URL) == cards
+        assert [c[0] for c in calls] == [RIFTBOUND_RIOT_URL, RIFTBOUND_FALLBACK_URL]
+
+    def test_url_override_is_fetched_as_is(self, monkeypatch):
+        monkeypatch.setenv("RIOT_API_KEY", "RGAPI-test")
+        calls = self._record(monkeypatch, [{"id": 1}])
+        _fetch_riftbound("https://mirror.example/cards")
+        assert calls == [("https://mirror.example/cards", {})]  # no token leak off-Riot
+
+    def test_riot_url_override_keeps_token(self, monkeypatch):
+        monkeypatch.setenv("RIOT_API_KEY", "RGAPI-test")
+        data = {"sets": []}
+        calls = self._record(monkeypatch, data)
+        url = "https://europe.api.riotgames.com/riftbound/content/v1/contents?locale=en"
+        assert _fetch_riftbound(url) == data
+        assert calls == [(url, {"X-Riot-Token": "RGAPI-test"})]
+
+    def test_pagination_assembles_full_pages(self, monkeypatch):
+        monkeypatch.delenv("RIOT_API_KEY", raising=False)
+        page1 = [{"id": i} for i in range(48)]
+        page2 = [{"id": 48}]
+
+        def responses(url):
+            return page2 if "offset=48" in url else page1
+
+        calls = self._record(monkeypatch, responses)
+        assert _fetch_riftbound(RIFTBOUND_RIOT_URL) == page1 + page2
+        assert len(calls) == 2
+
+    def test_pagination_stops_when_offset_is_ignored(self, monkeypatch):
+        monkeypatch.delenv("RIOT_API_KEY", raising=False)
+        page = [{"id": i} for i in range(48)]  # same first id every time
+        calls = self._record(monkeypatch, page)
+        assert _fetch_riftbound(RIFTBOUND_RIOT_URL) == page
+        assert len(calls) == 2  # second (repeated) page detected and dropped
+
+    def test_pagination_unwraps_cards_dict(self, monkeypatch):
+        monkeypatch.delenv("RIOT_API_KEY", raising=False)
+        calls = self._record(monkeypatch, {"cards": [{"id": 1}]})
+        assert _fetch_riftbound(RIFTBOUND_RIOT_URL) == [{"id": 1}]
+        assert len(calls) == 1
+
+
 class TestDownloadNewImages:
     @pytest.fixture(autouse=True)
     def _no_network(self, monkeypatch):
@@ -91,7 +225,7 @@ class TestDownloadNewImages:
         self.data = {"cards": [_card("9", 41), _card("9", 42)]}
 
     def test_unsupported_game_returns_none(self, tmp_path):
-        assert download_new_images("Riftbound", out_dir=str(tmp_path)) is None
+        assert download_new_images("NotAGame", out_dir=str(tmp_path)) is None
 
     def test_downloads_with_padded_names(self, tmp_path):
         stats = download_new_images("Lorcana", out_dir=str(tmp_path), delay=0)
@@ -153,3 +287,17 @@ class TestDownloadNewImages:
     def test_limit_caps_downloads(self, tmp_path):
         stats = download_new_images("Lorcana", out_dir=str(tmp_path), limit=1, delay=0)
         assert stats.downloaded == 1
+
+    def test_riftbound_downloads_with_padded_names(self, tmp_path, monkeypatch):
+        cards = [
+            {"set": "OGN", "collectorNumber": 1, "art": {"fullUrl": "http://img/1.jpg"}},
+            {"set": "OGN", "collector_number": "23c", "media": {"image_url": "http://img/23c.jpg"}},
+        ]
+        monkeypatch.setitem(
+            image_fetcher.GAMES,
+            "riftbound",
+            ("stub://cards", lambda url: cards, riftbound_targets),
+        )
+        stats = download_new_images("Riftbound", out_dir=str(tmp_path), delay=0)
+        assert stats == FetchStats(downloaded=2, skipped=0, failed=0)
+        assert sorted(p.name for p in tmp_path.iterdir()) == ["OGN-001.webp", "OGN-23c.webp"]

--- a/tests/test_image_fetcher.py
+++ b/tests/test_image_fetcher.py
@@ -112,6 +112,7 @@ class TestRiftboundTargets:
             {"collectorNumber": 2, "image_url": "u"},                    # no set
             {"set": "OGN", "image_url": "u"},                            # no number
             {"set": "OGN", "collectorNumber": 3, "image": {"x": "y"}},   # non-string url
+            {"set": {"id": "OGN"}, "number": 4, "image_url": "u"},       # nested set object
             "not-a-dict",
         ]
         assert list(riftbound_targets(data)) == []


### PR DESCRIPTION
Adds full support for downloading Riftbound card images from the official Riot content API (with fallback to the open Riftcodex API), completing the second game implementation alongside Lorcana.

## Summary
Extends `image_fetcher.py` to handle Riftbound card art downloads by:
- Implementing `_fetch_riftbound()` to intelligently select between the official Riot API (when `RIOT_API_KEY` env var is set) and the open Riftcodex fallback
- Adding `riftbound_targets()` parser that handles both Riot content endpoint and Riftcodex payload shapes, with flexible field name handling (camelCase/snake_case)
- Registering Riftbound in the `GAMES` registry alongside Lorcana
- Comprehensive test coverage for both data parsing and API source selection/fallback logic

## Key Changes
- **`_fetch_riftbound(url)`**: Orchestrates source selection and pagination
  - Uses Riot API with `X-Riot-Token` header when `RIOT_API_KEY` is set
  - Falls back to Riftcodex API on missing key or Riot API failure
  - Respects explicit URL overrides (no token leak to non-Riot hosts)
  - Handles offset-based pagination (48-card pages) with duplicate detection

- **`riftbound_targets(data)`**: Yields `(set_code, number, image_url)` tuples
  - Parses both Riot content shape (`sets → cards → art.fullUrl`) and Riftcodex shape (flat cards with `media.image_url`)
  - Tolerates multiple field name variants (e.g., `collectorNumber` / `collector_number` / `number`)
  - Deduplicates on first occurrence (no promo-collision rule like Lorcana)
  - Skips incomplete cards gracefully

- **Helper functions**:
  - `_riot_api_key()`: Reads and trims `RIOT_API_KEY` env var
  - `_is_riot_host(url)`: Detects Riot API domains for conditional token attachment
  - `_fetch_riftbound_pages(url)`: Implements offset pagination with loop termination
  - `_riftbound_cards(data)`: Flattens both payload shapes into a card stream
  - `_first_field(card, *names)`: Utility for flexible field lookup

- **Test coverage** (`TestRiftboundTargets`, `TestFetchRiftbound`):
  - Payload shape parsing (Riot and Riftcodex formats)
  - API source selection (key present/absent, Riot failure)
  - Pagination assembly and termination
  - URL override behavior (token leakage prevention)
  - Deduplication and incomplete card skipping

- **Integration**: Updated `GAMES` registry and `download_new_images()` docstring; fixed test that incorrectly referenced "Riftbound" as unsupported.

## Implementation Notes
- Pagination uses a 200-iteration hard cap and detects repeated first IDs to avoid infinite loops on misbehaving APIs
- The Riot API header is only attached to `*.api.riotgames.com` hosts, preventing accidental token leakage to mirrors
- Both payload shapes are handled transparently; callers don't need to know which API was used
- Follows existing Lorcana patterns (game registry, targets iterator, stats tracking)

https://claude.ai/code/session_01WYNiPtpQer8wWZPQGwZwMj